### PR TITLE
Correct multi-cluster README.md GitRepo manifests to use 'fleet-default' namespace

### DIFF
--- a/multi-cluster/helm-external/README.md
+++ b/multi-cluster/helm-external/README.md
@@ -15,7 +15,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: helm-external
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-examples
   paths:

--- a/multi-cluster/helm-kustomize/README.md
+++ b/multi-cluster/helm-kustomize/README.md
@@ -15,7 +15,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: helm-kustomize
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-examples
   paths:

--- a/multi-cluster/helm/README.md
+++ b/multi-cluster/helm/README.md
@@ -15,7 +15,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: helm
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-examples
   paths:

--- a/multi-cluster/kustomize/README.md
+++ b/multi-cluster/kustomize/README.md
@@ -14,7 +14,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: kustomize
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-examples
   paths:

--- a/multi-cluster/manifests/README.md
+++ b/multi-cluster/manifests/README.md
@@ -14,7 +14,7 @@ kind: GitRepo
 apiVersion: fleet.cattle.io/v1alpha1
 metadata:
   name: manifests
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   repo: https://github.com/rancher/fleet-examples
   paths:

--- a/tests/expected/multi-cluster/helm-external/bundle.yaml
+++ b/tests/expected/multi-cluster/helm-external/bundle.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     fleet.cattle.io/commit: fake
   name: test
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   helm:
     chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
@@ -182,7 +182,7 @@ spec:
       apiVersion: fleet.cattle.io/v1alpha1
       metadata:
         name: helm-external
-        namespace: fleet-local
+        namespace: fleet-default
       spec:
         repo: https://github.com/rancher/fleet-examples
         paths:

--- a/tests/expected/multi-cluster/helm-kustomize/bundle.yaml
+++ b/tests/expected/multi-cluster/helm-kustomize/bundle.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     fleet.cattle.io/commit: fake
   name: test
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   helm:
     chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
@@ -182,7 +182,7 @@ spec:
       apiVersion: fleet.cattle.io/v1alpha1
       metadata:
         name: helm-kustomize
-        namespace: fleet-local
+        namespace: fleet-default
       spec:
         repo: https://github.com/rancher/fleet-examples
         paths:

--- a/tests/expected/multi-cluster/helm/bundle.yaml
+++ b/tests/expected/multi-cluster/helm/bundle.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     fleet.cattle.io/commit: fake
   name: test
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   namespace: fleet-mc-helm-example
   resources:
@@ -33,7 +33,7 @@ spec:
       apiVersion: fleet.cattle.io/v1alpha1
       metadata:
         name: helm
-        namespace: fleet-local
+        namespace: fleet-default
       spec:
         repo: https://github.com/rancher/fleet-examples
         paths:

--- a/tests/expected/multi-cluster/kustomize/bundle.yaml
+++ b/tests/expected/multi-cluster/kustomize/bundle.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     fleet.cattle.io/commit: fake
   name: test
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   namespace: fleet-mc-kustomize-example
   resources:
@@ -25,7 +25,7 @@ spec:
       apiVersion: fleet.cattle.io/v1alpha1
       metadata:
         name: kustomize
-        namespace: fleet-local
+        namespace: fleet-default
       spec:
         repo: https://github.com/rancher/fleet-examples
         paths:

--- a/tests/expected/multi-cluster/manifests/bundle.yaml
+++ b/tests/expected/multi-cluster/manifests/bundle.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     fleet.cattle.io/commit: fake
   name: test
-  namespace: fleet-local
+  namespace: fleet-default
 spec:
   namespace: fleet-mc-manifest-example
   resources:
@@ -25,7 +25,7 @@ spec:
       apiVersion: fleet.cattle.io/v1alpha1
       metadata:
         name: manifests
-        namespace: fleet-local
+        namespace: fleet-default
       spec:
         repo: https://github.com/rancher/fleet-examples
         paths:

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -28,7 +28,7 @@ for i in ../multi-cluster/*; do
     for j in dev test prod; do
         mkdir -p ../../tests/output/garbage/${i}
         fleet test -l env=${j} > ../../tests/output/garbage/${i}/${j}-output.yaml
-        fleet apply -o - test > ../../tests/output/garbage/${i}/bundle.yaml
+        fleet apply -n fleet-default -o - test > ../../tests/output/garbage/${i}/bundle.yaml
     done
     popd
 done


### PR DESCRIPTION
Correct multi-cluster README.md GitRepo manifests to use 'fleet-default' namespace