### PR TITLE
arm64のイメージ用とx86イメージ用のoverlaysを用意

### DIFF
--- a/single-cluster/kustomize/overlays/arm64/kustomization.yaml
+++ b/single-cluster/kustomize/overlays/arm64/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+- ../../base
+patches:
+- redis-slave-deployment.yaml
+- redis-slave-service.yaml
+
+images:
+- name: gcr.io/google-samples/gb-frontend
+  newname: gcr.io/google-samples/gb-frontend-arm64
+  newTag: v5

--- a/single-cluster/kustomize/overlays/arm64/redis-slave-deployment.yaml
+++ b/single-cluster/kustomize/overlays/arm64/redis-slave-deployment.yaml
@@ -1,0 +1,6 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: redis-slave
+spec:
+  replicas: 0

--- a/single-cluster/kustomize/overlays/arm64/redis-slave-service.yaml
+++ b/single-cluster/kustomize/overlays/arm64/redis-slave-service.yaml
@@ -1,0 +1,7 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: redis-slave
+spec:
+  selector:
+    role: master

--- a/single-cluster/kustomize/overlays/x86/kustomization.yaml
+++ b/single-cluster/kustomize/overlays/x86/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../base
+patches:
+- redis-slave-deployment.yaml
+- redis-slave-service.yaml

--- a/single-cluster/kustomize/overlays/x86/redis-slave-deployment.yaml
+++ b/single-cluster/kustomize/overlays/x86/redis-slave-deployment.yaml
@@ -1,0 +1,6 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: redis-slave
+spec:
+  replicas: 0

--- a/single-cluster/kustomize/overlays/x86/redis-slave-service.yaml
+++ b/single-cluster/kustomize/overlays/x86/redis-slave-service.yaml
@@ -1,0 +1,7 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: redis-slave
+spec:
+  selector:
+    role: master


### PR DESCRIPTION
元々のimage指定がx86のみなので、x86とarm64両方をサポートできるようにimageの指定をoverlaysで吸収しました。