### PR TITLE
Update Redis images to avoid vsyscall use

### DIFF
--- a/multi-cluster/helm/templates/redis-master-deployment.yaml
+++ b/multi-cluster/helm/templates/redis-master-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis
+        image: k8s.gcr.io/redis:e2e
         resources:
           requests:
             cpu: 100m

--- a/multi-cluster/helm/templates/redis-slave-deployment.yaml
+++ b/multi-cluster/helm/templates/redis-slave-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+        image: gcr.io/google_samples/gb-redisslave:v2
         resources:
           requests:
             cpu: 100m

--- a/multi-cluster/kustomize/base/redis-master-deployment.yaml
+++ b/multi-cluster/kustomize/base/redis-master-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis
+        image: k8s.gcr.io/redis:e2e
         resources:
           requests:
             cpu: 100m

--- a/multi-cluster/kustomize/base/redis-slave-deployment.yaml
+++ b/multi-cluster/kustomize/base/redis-slave-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+        image: gcr.io/google_samples/gb-redisslave:v2
         resources:
           requests:
             cpu: 100m

--- a/simple/redis-master-deployment.yaml
+++ b/simple/redis-master-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: redis
+        image: k8s.gcr.io/redis:e2e
         resources:
           requests:
             cpu: 100m

--- a/simple/redis-slave-deployment.yaml
+++ b/simple/redis-slave-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: slave
-        image: gcr.io/google_samples/gb-redisslave:v1
+        image: gcr.io/google_samples/gb-redisslave:v2
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
The current Redis images specified in the examples will segfault when on recent kernel versions, due to the fact vsyscalls have been disabled by default for security reasons (and Redis images use glibc old enough to make use of them).

So in order to run those examples, users must specified the `vsyscall=emulate` kernel command line parameter. This fails, for example, in Rancher Desktop for example.

This PR updates images to address that issue.

Details at: https://github.com/rancher-sandbox/rancher-desktop/issues/2215