### PR TITLE
Add OCI registry based Helm example

### DIFF
--- a/single-cluster/helm-oci/fleet.yaml
+++ b/single-cluster/helm-oci/fleet.yaml
@@ -1,0 +1,32 @@
+# This file and all contents in it are OPTIONAL.
+
+# The namespace this chart will be installed and restricted to,
+# if not specified the chart will be installed to "default"
+namespace: fleet-helm-oci-example
+
+# Custom helm options
+helm:
+  # The release name to use. If empty a generated release name will be used
+  releaseName: guestbook
+
+  # The directory of the chart in the repo.  Also any valid go-getter supported
+  # URL can be used there is specify where to download the chart from.
+  # If repo below is set this value if the chart name in the repo
+  chart: "oci://ghcr.io/fleetrepoci/guestbook"
+
+  # An https to a valid Helm repository to download the chart from
+  repo: ""
+
+  # Used if repo is set to look up the version of the chart
+  version: "0.0.0"
+
+  # Force recreate resource that can not be updated
+  force: false
+
+  # How long for helm to wait for the release to be active. If the value
+  # is less that or equal to zero, we will not wait in Helm
+  timeoutSeconds: 0
+
+  # Custom values that will be passed as values.yaml to the installation
+  values:
+    replicas: 2


### PR DESCRIPTION
the `version` part is used to determine which chart release should be downloaded from the OCI based registry.