### PR TITLE
Use `patchesStrategicMerge` for Kustomize patching

### DIFF
--- a/multi-cluster/helm-kustomize/overlays/dev/kustomization.yaml
+++ b/multi-cluster/helm-kustomize/overlays/dev/kustomization.yaml
@@ -1,3 +1,3 @@
-patches:
+patchesStrategicMerge:
 - redis-slave-deployment.yaml
 - redis-slave-service.yaml

--- a/multi-cluster/helm-kustomize/overlays/prod/kustomization.yaml
+++ b/multi-cluster/helm-kustomize/overlays/prod/kustomization.yaml
@@ -1,3 +1,3 @@
-patches:
+patchesStrategicMerge:
 - frontend-deployment.yaml
 - frontend-service.yaml

--- a/multi-cluster/helm-kustomize/overlays/test/kustomization.yaml
+++ b/multi-cluster/helm-kustomize/overlays/test/kustomization.yaml
@@ -1,2 +1,2 @@
-patches:
+patchesStrategicMerge:
 - frontend-deployment.yaml

--- a/multi-cluster/kustomize/overlays/dev/kustomization.yaml
+++ b/multi-cluster/kustomize/overlays/dev/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
 - ../../base
-patches:
+patchesStrategicMerge:
 - redis-slave-deployment.yaml
 - redis-slave-service.yaml

--- a/multi-cluster/kustomize/overlays/prod/kustomization.yaml
+++ b/multi-cluster/kustomize/overlays/prod/kustomization.yaml
@@ -1,5 +1,5 @@
 resources:
 - ../../base
-patches:
+patchesStrategicMerge:
 - frontend-deployment.yaml
 - frontend-service.yaml

--- a/multi-cluster/kustomize/overlays/test/kustomization.yaml
+++ b/multi-cluster/kustomize/overlays/test/kustomization.yaml
@@ -1,4 +1,4 @@
 resources:
 - ../../base
-patches:
+patchesStrategicMerge:
 - frontend-deployment.yaml

--- a/single-cluster/helm-kustomize/overlays/dev/kustomization.yaml
+++ b/single-cluster/helm-kustomize/overlays/dev/kustomization.yaml
@@ -1,3 +1,3 @@
-patches:
+patchesStrategicMerge:
 - redis-slave-deployment.yaml
 - redis-slave-service.yaml

--- a/single-cluster/kustomize/overlays/dev/kustomization.yaml
+++ b/single-cluster/kustomize/overlays/dev/kustomization.yaml
@@ -1,5 +1,5 @@
 bases:
 - ../../base
-patches:
+patchesStrategicMerge:
 - redis-slave-deployment.yaml
 - redis-slave-service.yaml

--- a/tests/expected/multi-cluster/helm-kustomize/bundle.yaml
+++ b/tests/expected/multi-cluster/helm-kustomize/bundle.yaml
@@ -231,7 +231,7 @@ spec:
           dir: overlays/prod
     name: fleet.yaml
   - content: |
-      patches:
+      patchesStrategicMerge:
       - redis-slave-deployment.yaml
       - redis-slave-service.yaml
     name: overlays/dev/kustomization.yaml
@@ -269,7 +269,7 @@ spec:
         type: LoadBalancer
     name: overlays/prod/frontend-service.yaml
   - content: |
-      patches:
+      patchesStrategicMerge:
       - frontend-deployment.yaml
       - frontend-service.yaml
     name: overlays/prod/kustomization.yaml
@@ -282,7 +282,7 @@ spec:
         replicas: 3
     name: overlays/test/frontend-deployment.yaml
   - content: |
-      patches:
+      patchesStrategicMerge:
       - frontend-deployment.yaml
     name: overlays/test/kustomization.yaml
   targets:

--- a/tests/expected/multi-cluster/kustomize/bundle.yaml
+++ b/tests/expected/multi-cluster/kustomize/bundle.yaml
@@ -219,7 +219,7 @@ spec:
   - content: |
       resources:
       - ../../base
-      patches:
+      patchesStrategicMerge:
       - redis-slave-deployment.yaml
       - redis-slave-service.yaml
     name: overlays/dev/kustomization.yaml
@@ -259,7 +259,7 @@ spec:
   - content: |
       resources:
       - ../../base
-      patches:
+      patchesStrategicMerge:
       - frontend-deployment.yaml
       - frontend-service.yaml
     name: overlays/prod/kustomization.yaml
@@ -274,7 +274,7 @@ spec:
   - content: |
       resources:
       - ../../base
-      patches:
+      patchesStrategicMerge:
       - frontend-deployment.yaml
     name: overlays/test/kustomization.yaml
   targets:

--- a/tests/expected/single-cluster/helm-kustomize/bundle.yaml
+++ b/tests/expected/single-cluster/helm-kustomize/bundle.yaml
@@ -198,7 +198,7 @@ spec:
         dir: overlays/dev
     name: fleet.yaml
   - content: |
-      patches:
+      patchesStrategicMerge:
       - redis-slave-deployment.yaml
       - redis-slave-service.yaml
     name: overlays/dev/kustomization.yaml

--- a/tests/expected/single-cluster/kustomize/bundle.yaml
+++ b/tests/expected/single-cluster/kustomize/bundle.yaml
@@ -192,7 +192,7 @@ spec:
   - content: |
       bases:
       - ../../base
-      patches:
+      patchesStrategicMerge:
       - redis-slave-deployment.yaml
       - redis-slave-service.yaml
     name: overlays/dev/kustomization.yaml


### PR DESCRIPTION
Drop for legacy-style patching was [dropped](https://github.com/kubernetes-sigs/kustomize/releases/tag/api%2Fv0.13.0) in `sigs.k8s.io/kustomize/api` `v0.13.0`, causing Fleet acceptance tests for Kustomize examples to fail ([example](https://github.com/rancher/fleet/actions/runs/6272321778/job/170336357960)), with errors such as:
```
error while running post render on files: invalid Kustomization: json: cannot unmarshal string into Go struct field Kustomization.patches of type types.Patch]
```