### PR TITLE
Update frontend-deployment.yaml

### DIFF
--- a/simple/frontend-deployment.yaml
+++ b/simple/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v5
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Update the frontend image based on new instructions from google https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook

Attempting to deploy the simple example this morning resulted in an ImagePullBackOff.