### PR TITLE
pin the tag with sha

### DIFF
--- a/single-cluster/kustomize/base/frontend-deployment.yaml
+++ b/single-cluster/kustomize/base/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v5
+        image: gcr.io/google-samples/gb-frontend@sha256:e5233a1e2a6dc9c4ae1d1b754e3a3f62ecdc1da81b31422aff4e7390a0c6e534
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
- The image tag `v5` doesn't exist in https://console.cloud.google.com/gcr/images/google-samples/GLOBAL/gb-frontend?pli=1 so it is replaced with an existing sha tag.