### PR TITLE
Multi gitrepo example.

### DIFF
--- a/single-cluster/helm/templates/frontend-deployment.yaml
+++ b/single-cluster/helm/templates/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google-samples/gb-frontend:v5
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         resources:
           requests:
             cpu: 100m

--- a/single-cluster/multi-gitrepo/README.md
+++ b/single-cluster/multi-gitrepo/README.md
@@ -1,0 +1,20 @@
+# Multi-GitRepo example
+
+This example will deploy the [Kubernetes sample guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) application using 2 different `GitRepo CRs`, splitting the frontend and the backend as different Helm charts.
+
+The initial `GitRepo` will point to a folder containing 2 `GitRepo` resources that will be deployed in cascade. 
+
+The app will be deployed into the `fleet-helm-example` namespace.
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: multi-gitrepo
+  namespace: fleet-local
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  paths:
+  - single-cluster/multi-gitrepos/gitrepos
+```
+

--- a/single-cluster/multi-gitrepo/frontend/Chart.yaml
+++ b/single-cluster/multi-gitrepo/frontend/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: guestbook-frontend
+description: Sample application frontend
+version: 0.0.0
+appVersion: 0.0.0

--- a/single-cluster/multi-gitrepo/frontend/README.md
+++ b/single-cluster/multi-gitrepo/frontend/README.md
@@ -1,0 +1,6 @@
+# Multi-GitRepo example (frontend)
+
+This example will deploy the [Kubernetes sample guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) frontend application packaged as a Helm chart.
+The app will be deployed into the `fleet-helm-example` namespace.
+It will be deployed as part of the [multi-gitrepo](https://github.com/rancher/fleet-examples/single-cluster/multi-gitrepo) example.
+

--- a/single-cluster/multi-gitrepo/frontend/fleet.yaml
+++ b/single-cluster/multi-gitrepo/frontend/fleet.yaml
@@ -1,0 +1,32 @@
+# This file and all contents in it are OPTIONAL.
+
+# The namespace this chart will be installed and restricted to,
+# if not specified the chart will be installed to "default"
+namespace: fleet-helm-example
+
+# Custom helm options
+helm:
+  # The release name to use. If empty a generated release name will be used
+  releaseName: guestbook-frontend
+
+  # The directory of the chart in the repo.  Also any valid go-getter supported
+  # URL can be used there is specify where to download the chart from.
+  # If repo below is set this value if the chart name in the repo
+  chart: ""
+
+  # An https to a valid Helm repository to download the chart from
+  repo: ""
+
+  # Used if repo is set to look up the version of the chart
+  version: ""
+
+  # Force recreate resource that can not be updated
+  force: false
+
+  # How long for helm to wait for the release to be active. If the value
+  # is less that or equal to zero, we will not wait in Helm
+  timeoutSeconds: 0
+
+  # Custom values that will be passed as values.yaml to the installation
+  values:
+    replicas: 2

--- a/single-cluster/multi-gitrepo/frontend/templates/frontend-deployment.yaml
+++ b/single-cluster/multi-gitrepo/frontend/templates/frontend-deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+spec:
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
+  replicas: {{ .Values.replicas }}
+  template:
+    metadata:
+      labels:
+        app: guestbook
+        tier: frontend
+    spec:
+      containers:
+      - name: php-redis
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 80

--- a/single-cluster/multi-gitrepo/frontend/templates/frontend-service.yaml
+++ b/single-cluster/multi-gitrepo/frontend/templates/frontend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  labels:
+    app: guestbook
+    tier: frontend
+spec:
+  type: "{{ .Values.serviceType }}"
+  ports:
+  - port: 80
+  selector:
+    app: guestbook
+    tier: frontend

--- a/single-cluster/multi-gitrepo/frontend/values.yaml
+++ b/single-cluster/multi-gitrepo/frontend/values.yaml
@@ -1,0 +1,3 @@
+replication: true
+replicas: 1
+serviceType: NodePort

--- a/single-cluster/multi-gitrepo/gitrepos/README.md
+++ b/single-cluster/multi-gitrepo/gitrepos/README.md
@@ -1,0 +1,4 @@
+# Multi-GitRepo example (gitrepos)
+
+This folder contains the `GitRepo CRs` that will be deployed in the [multi-gitrepo](https://github.com/rancher/fleet-examples/single-cluster/multi-gitrepo) example.
+

--- a/single-cluster/multi-gitrepo/gitrepos/frontend.yaml
+++ b/single-cluster/multi-gitrepo/gitrepos/frontend.yaml
@@ -1,0 +1,11 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: multigitrepo-frontend
+  namespace: fleet-local
+spec:
+  repo: https://github.com/0xavi0/fleet-examples
+  branch: multi-gitrepo
+  paths:
+  - single-cluster/multi-gitrepo/frontend
+

--- a/single-cluster/multi-gitrepo/gitrepos/redis.yaml
+++ b/single-cluster/multi-gitrepo/gitrepos/redis.yaml
@@ -1,0 +1,11 @@
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: multigitrepo-redis
+  namespace: fleet-local
+spec:
+  repo: https://github.com/0xavi0/fleet-examples
+  branch: multi-gitrepo
+  paths:
+  - single-cluster/multi-gitrepo/redis
+

--- a/single-cluster/multi-gitrepo/redis/Chart.yaml
+++ b/single-cluster/multi-gitrepo/redis/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: guestbook-redis
+description: Sample application (redis)
+version: 0.0.0
+appVersion: 0.0.0

--- a/single-cluster/multi-gitrepo/redis/README.md
+++ b/single-cluster/multi-gitrepo/redis/README.md
@@ -1,0 +1,6 @@
+# Helm Example
+
+This example will deploy the [Kubernetes sample guestbook](https://github.com/kubernetes/examples/tree/master/guestbook/) application backend packaged as a Helm chart.
+The app will be deployed into the `fleet-helm-example` namespace.
+It will be deployed as part of the [multi-gitrepo](https://github.com/rancher/fleet-examples/single-cluster/multi-gitrepo) example.
+

--- a/single-cluster/multi-gitrepo/redis/fleet.yaml
+++ b/single-cluster/multi-gitrepo/redis/fleet.yaml
@@ -1,0 +1,32 @@
+# This file and all contents in it are OPTIONAL.
+
+# The namespace this chart will be installed and restricted to,
+# if not specified the chart will be installed to "default"
+namespace: fleet-helm-example
+
+# Custom helm options
+helm:
+  # The release name to use. If empty a generated release name will be used
+  releaseName: guestbook-redis
+
+  # The directory of the chart in the repo.  Also any valid go-getter supported
+  # URL can be used there is specify where to download the chart from.
+  # If repo below is set this value if the chart name in the repo
+  chart: ""
+
+  # An https to a valid Helm repository to download the chart from
+  repo: ""
+
+  # Used if repo is set to look up the version of the chart
+  version: ""
+
+  # Force recreate resource that can not be updated
+  force: false
+
+  # How long for helm to wait for the release to be active. If the value
+  # is less that or equal to zero, we will not wait in Helm
+  timeoutSeconds: 0
+
+  # Custom values that will be passed as values.yaml to the installation
+  values:
+    replicas: 2

--- a/single-cluster/multi-gitrepo/redis/templates/redis-master-deployment.yaml
+++ b/single-cluster/multi-gitrepo/redis/templates/redis-master-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: master
+        tier: backend
+    spec:
+      containers:
+      - name: master
+        image: registry.k8s.io/redis:e2e
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379

--- a/single-cluster/multi-gitrepo/redis/templates/redis-master-service.yaml
+++ b/single-cluster/multi-gitrepo/redis/templates/redis-master-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  labels:
+    app: redis
+    role: master
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+    role: master
+    tier: backend

--- a/single-cluster/multi-gitrepo/redis/templates/redis-slave-deployment.yaml
+++ b/single-cluster/multi-gitrepo/redis/templates/redis-slave-deployment.yaml
@@ -1,0 +1,29 @@
+{{ if .Values.replication }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-slave
+spec:
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: redis
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: gcr.io/google_samples/gb-redisslave:v2
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379
+{{ end }}

--- a/single-cluster/multi-gitrepo/redis/templates/redis-slave-service.yaml
+++ b/single-cluster/multi-gitrepo/redis/templates/redis-slave-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-slave
+  labels:
+    app: redis
+    role: slave
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: redis
+    {{ if .Values.replication }}
+    role: slave
+    {{ else }}
+    role: master
+    {{ end }}
+    tier: backend

--- a/single-cluster/multi-gitrepo/redis/values.yaml
+++ b/single-cluster/multi-gitrepo/redis/values.yaml
@@ -1,0 +1,3 @@
+replication: true
+replicas: 1
+serviceType: NodePort


### PR DESCRIPTION
This example splits the guestbook deployment into 2 gitrepos to show a multi (nested) GitRepo example.

The example will be referenced in the docs. 

Refers: https://github.com/rancher/fleet/issues/1631