### PR TITLE
update windows image to correct tag ltsc2022

### DIFF
--- a/multi-cluster/windows-helm/fleet.yaml
+++ b/multi-cluster/windows-helm/fleet.yaml
@@ -4,10 +4,18 @@ targetCustomizations:
   helm:
     values:
       image:
-        tag: 2022
+        tag: ltsc2022
   clusterSelector:
     matchLabels:
       windows.version: win2022
+- name: win2019
+  helm:
+    values:
+      image:
+        tag: ltsc2019
+  clusterSelector:
+    matchLabels:
+      windows.version: win2019
 - name: win2004
   helm:
     values:

--- a/multi-cluster/windows-helm/values.yaml
+++ b/multi-cluster/windows-helm/values.yaml
@@ -1,2 +1,2 @@
 image:
-  tag: 2022
+  tag: ltsc2022


### PR DESCRIPTION
windows 2022 upstream image is `ltsc2022`, 2022 image is not available: https://mcr.microsoft.com/en-us/product/windows/servercore/tags

also, added a section for 2019 version support in fleet.yaml