### PR TITLE
Change references of guestbook-0.0.0.tgz to guestbook-0.0.1.tgz

### DIFF
--- a/multi-cluster/helm-external/fleet.yaml
+++ b/multi-cluster/helm-external/fleet.yaml
@@ -1,6 +1,6 @@
 namespace: fleet-mc-helm-external-example
 helm:
-  chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+  chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
 targetCustomizations:
 - name: dev
   helm:

--- a/multi-cluster/helm-kustomize/fleet.yaml
+++ b/multi-cluster/helm-kustomize/fleet.yaml
@@ -1,6 +1,6 @@
 namespace: fleet-mc-helm-kustomize-example
 helm:
-  chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+  chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
 targetCustomizations:
 - name: dev
   clusterSelector:

--- a/single-cluster/helm-kustomize/fleet.yaml
+++ b/single-cluster/helm-kustomize/fleet.yaml
@@ -5,6 +5,6 @@
 
 namespace: fleet-helm-kustomize-example
 helm:
-  chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+  chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
 kustomize:
   dir: overlays/dev

--- a/tests/expected/multi-cluster/helm-external/bundle.yaml
+++ b/tests/expected/multi-cluster/helm-external/bundle.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   correctDrift: {}
   helm:
-    chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+    chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
   ignore: {}
   namespace: fleet-mc-helm-external-example
   resources:
@@ -209,7 +209,7 @@ spec:
   - content: |
       namespace: fleet-mc-helm-external-example
       helm:
-        chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+        chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
       targetCustomizations:
       - name: dev
         helm:
@@ -242,7 +242,7 @@ spec:
         env: dev
     correctDrift: {}
     helm:
-      chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+      chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
       values:
         replication: false
     ignore: {}
@@ -252,7 +252,7 @@ spec:
         env: test
     correctDrift: {}
     helm:
-      chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+      chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
       values:
         replicas: 3
     ignore: {}
@@ -262,7 +262,7 @@ spec:
         env: prod
     correctDrift: {}
     helm:
-      chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+      chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
       values:
         replicas: 3
         serviceType: LoadBalancer

--- a/tests/expected/multi-cluster/helm-kustomize/bundle.yaml
+++ b/tests/expected/multi-cluster/helm-kustomize/bundle.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   correctDrift: {}
   helm:
-    chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+    chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
   ignore: {}
   namespace: fleet-mc-helm-kustomize-example
   resources:
@@ -209,7 +209,7 @@ spec:
   - content: |
       namespace: fleet-mc-helm-kustomize-example
       helm:
-        chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+        chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
       targetCustomizations:
       - name: dev
         clusterSelector:

--- a/tests/expected/single-cluster/helm-kustomize/bundle.yaml
+++ b/tests/expected/single-cluster/helm-kustomize/bundle.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   correctDrift: {}
   helm:
-    chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+    chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
   ignore: {}
   kustomize:
     dir: overlays/dev
@@ -195,7 +195,7 @@ spec:
 
       namespace: fleet-helm-kustomize-example
       helm:
-        chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.0.tgz
+        chart: https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz
       kustomize:
         dir: overlays/dev
     name: fleet.yaml


### PR DESCRIPTION
Use the recently created [guestbook-0.0.1.tgz](https://github.com/rancher/fleet-examples/releases/download/example/guestbook-0.0.1.tgz) which references the correct container images.