### PR TITLE
User driven helm overlays example

### DIFF
--- a/single-cluster/helm-overlays/README.md
+++ b/single-cluster/helm-overlays/README.md
@@ -1,0 +1,21 @@
+# Single Helm chart shared between 3 Bundles example
+
+This example deploys the same Helm chart in 3 different Bundles with their own Helm values.
+It also demonstrates how to use [user-driven scan](https://fleet.rancher.io/next/explanations/gitrepo-content#_alternative_scan_explicitly_defined_by_the_user).
+
+```yaml
+kind: GitRepo
+apiVersion: fleet.cattle.io/v1alpha1
+metadata:
+  name: test-helm-overlays
+  namespace: fleet-local
+spec:
+  repo: https://github.com/rancher/fleet-examples
+  bundles:
+    - base: single-cluster/helm-overlays
+      options: overlays/development/fleet.yaml
+    - base: single-cluster/helm-overlays
+      options: overlays/test/test.yaml
+    - base: single-cluster/helm-overlays
+      options: overlays/production/prod.yaml
+```

--- a/single-cluster/helm-overlays/overlays/development/development-values.yaml
+++ b/single-cluster/helm-overlays/overlays/development/development-values.yaml
@@ -1,0 +1,1 @@
+name: development

--- a/single-cluster/helm-overlays/overlays/development/fleet.yaml
+++ b/single-cluster/helm-overlays/overlays/development/fleet.yaml
@@ -1,0 +1,6 @@
+name: development-bundle
+defaultNamespace: development
+helm:
+  chart: ./superconfigmap
+  valuesFiles:
+  - overlays/development/development-values.yaml

--- a/single-cluster/helm-overlays/overlays/production/prod.yaml
+++ b/single-cluster/helm-overlays/overlays/production/prod.yaml
@@ -1,0 +1,7 @@
+name: prod-bundle
+defaultNamespace: production
+helm:
+  chart: ./superconfigmap
+  values:
+    name: production
+

--- a/single-cluster/helm-overlays/overlays/test/test-values.yaml
+++ b/single-cluster/helm-overlays/overlays/test/test-values.yaml
@@ -1,0 +1,1 @@
+name: test-env

--- a/single-cluster/helm-overlays/overlays/test/test.yaml
+++ b/single-cluster/helm-overlays/overlays/test/test.yaml
@@ -1,0 +1,6 @@
+name: test-bundle
+defaultNamespace: test-env
+helm:
+  chart: ./superconfigmap
+  valuesFiles:
+  - overlays/test/test-values.yaml

--- a/single-cluster/helm-overlays/superconfigmap/Chart.yaml
+++ b/single-cluster/helm-overlays/superconfigmap/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: superconfigmap
+description: A Helm chart that deploys a ConfigMap
+type: application
+version: 0.1.0

--- a/single-cluster/helm-overlays/superconfigmap/templates/configmap.yaml
+++ b/single-cluster/helm-overlays/superconfigmap/templates/configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.name }}
+data:
+  test: {{ .Values.name }}

--- a/single-cluster/helm-overlays/superconfigmap/values.yaml
+++ b/single-cluster/helm-overlays/superconfigmap/values.yaml
@@ -1,0 +1,1 @@
+name: my-configmap


### PR DESCRIPTION
This adds an example sharing a single Helm chart between 3 different Bundles using their own Helm values.

It also demonstrates how user-driven scan works. 