### PR TITLE
Fix supply chain risks in CI workflow

### DIFF
--- a/.github/scripts/install-k3d.sh
+++ b/.github/scripts/install-k3d.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Install k3d from a pinned release, verifying the SHA-256 checksum before
+# placing the binary on PATH.
+#
+# renovate: datasource=github-releases depName=k3d-io/k3d
+K3D_VERSION="v5.8.3"
+
+# shellcheck disable=SC2034
+# renovate: datasource=github-release-attachments depName=k3d-io/k3d digestVersion=v5.8.3
+K3D_SUM_amd64="dbaa79a76ace7f4ca230a1ff41dc7d8a5036a8ad0309e9c54f9bf3836dbe853e"
+# shellcheck disable=SC2034
+# renovate: datasource=github-release-attachments depName=k3d-io/k3d digestVersion=v5.8.3
+K3D_SUM_arm64="0b8110f2229631af7402fb828259330985918b08fefd38b7f1b788a1c8687216"
+
+set -euo pipefail
+
+ARCH=$(uname -m)
+case "${ARCH}" in
+  x86_64)  ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+  *) echo "Unsupported architecture: ${ARCH}"; exit 1 ;;
+esac
+
+DEST="${INSTALL_DIR:-${HOME}/.local/bin}"
+mkdir -p "${DEST}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+curl -sSfL \
+  "https://github.com/k3d-io/k3d/releases/download/${K3D_VERSION}/k3d-linux-${ARCH}" \
+  -o "${TMPDIR}/k3d"
+
+K3D_SUM_VAR="K3D_SUM_${ARCH}"
+echo "${!K3D_SUM_VAR}  ${TMPDIR}/k3d" | sha256sum -c -
+
+install -m 0755 "${TMPDIR}/k3d" "${DEST}/k3d"
+echo "Installed k3d ${K3D_VERSION} (${ARCH}) to ${DEST}/k3d"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,34 +35,66 @@ jobs:
           fi
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
       -
+        name: Cache k3d CLI
+        id: cache-k3d
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /home/runner/.local/bin/k3d
+          key: ${{ runner.os }}-k3d-${{ hashFiles('.github/scripts/install-k3d.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-k3d-
+      -
+        name: Install k3d
+        run: |
+          if [ "${{ steps.cache-k3d.outputs.cache-hit }}" != "true" ]; then
+            bash .github/scripts/install-k3d.sh
+          else
+            echo "Using cached k3d CLI"
+            chmod +x ~/.local/bin/k3d
+          fi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      -
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: fleet-cli-cache
         with:
-          path: /home/runner/.local/bin
+          path: /home/runner/.local/bin/fleet
           key: ${{ runner.os }}-fleet-cli-${{ steps.resolve-version.outputs.version }}
       -
         name: Download CLI
-        if: steps.fleet-cli-cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p /home/runner/.local/bin
-          wget -nv "https://github.com/rancher/fleet/releases/download/${{ steps.resolve-version.outputs.version }}/fleet-linux-amd64"
-          mv fleet-linux-amd64 /home/runner/.local/bin/fleet
-          chmod +x /home/runner/.local/bin/fleet
+          if [ "${{ steps.fleet-cli-cache.outputs.cache-hit }}" != "true" ]; then
+            FLEET_VER="${{ steps.resolve-version.outputs.version }}"
+            FLEET_VER_TRIM="${FLEET_VER#v}"
+            curl --silent --fail --location \
+              "https://github.com/rancher/fleet/releases/download/${FLEET_VER}/fleet_${FLEET_VER_TRIM}_checksums.txt" \
+              -o /tmp/fleet_checksums.txt
+            curl --silent --fail --location \
+              "https://github.com/rancher/fleet/releases/download/${FLEET_VER}/fleet-linux-amd64" \
+              -o /tmp/fleet-linux-amd64
+            (cd /tmp && grep "  fleet-linux-amd64$" fleet_checksums.txt | sha256sum --check --strict -)
+            install -m 0755 /tmp/fleet-linux-amd64 /home/runner/.local/bin/fleet
+          else
+            echo "Using cached fleet CLI"
+            chmod +x /home/runner/.local/bin/fleet
+          fi
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       -
         name: Set up k3d cluster
         run: |
-          # Install k3d
-          curl --silent --fail https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.8.3 bash
           # Create a minimal cluster (no load balancer needed)
           k3d cluster create fleet-test --no-lb --wait --timeout 120s
           k3d kubeconfig merge fleet-test --kubeconfig-merge-default
 
           # Install Fleet CRDs for the exact CLI version under test so that
           # `kubectl apply` and `fleet target` can use the Cluster CRD.
+          # Note: fleet does not publish checksums for Helm chart tarballs.
           FLEET_VER="${{ steps.resolve-version.outputs.version }}"
-          curl -sL "https://github.com/rancher/fleet/releases/download/${FLEET_VER}/fleet-crd-${FLEET_VER#v}.tgz" \
-            | tar -xz -O fleet-crd/templates/crds.yaml \
-            | kubectl apply -f -
+          FLEET_VER_TRIM="${FLEET_VER#v}"
+          curl --silent --fail --location \
+            "https://github.com/rancher/fleet/releases/download/${FLEET_VER}/fleet-crd-${FLEET_VER_TRIM}.tgz" \
+            -o /tmp/fleet-crd.tgz
+          tar -xz -O -f /tmp/fleet-crd.tgz fleet-crd/templates/crds.yaml | kubectl apply -f -
 
           # Create namespaces and minimal cluster objects for targeting
           kubectl create namespace fleet-local


### PR DESCRIPTION
Replace insecure download patterns (`curl | bash` k3d install, bare `wget` fleet CLI download) with verified, cached alternatives. Add a shared `install-k3d.sh` script (ported from `rancher/fleet`) that downloads the k3d binary and verifies it against a hardcoded sha256 checksum before installing, with Renovate annotations to keep the version and checksum in sync.

- `install-k3d.sh`: pinned to `v5.8.3` with sha256 checksums for both `amd64` and `arm64`. Called from a dedicated step and gated behind `actions/cache`, keyed on a hash of the script itself so the cache invalidates automatically when dependencies are updated.
- `fleet-linux-amd64`: replaced `wget` with `curl` and validates the binary against fleet's published `fleet_${VER}_checksums.txt` file using `sha256sum --check --strict`. Also cached, with conditional download on cache miss.
- `fleet-crd-*.tgz`: fleet does not publish checksums for Helm chart tarballs. The inline `curl | tar | kubectl` pipe is replaced with a two-step download-then-extract to avoid processing unauthenticated streamed content without an intermediate file.
- Both binaries are explicitly added to `$GITHUB_PATH` to ensure availability on the command line.